### PR TITLE
Remove hardcoded kmc path

### DIFF
--- a/src/MentaLiST.jl
+++ b/src/MentaLiST.jl
@@ -20,8 +20,18 @@ function kmerize_kmc(files, k, threads=1)
     filepath = files[1]
   end
   # now run:
-  run(`kmc -k$k -t$threads -ci0 $filepath $outpath /tmp`)
-  run(`kmc_tools transform $outpath dump $outpath`)
+  try
+    run(`kmc -k$k -t$threads -ci0 $filepath $outpath /tmp`)
+  catch e
+      println("caught error $e")
+      exit(1)
+  end
+  try
+    run(`kmc_tools transform $outpath dump $outpath`)
+  catch e
+      println("caught error $e")
+      exit(1)
+  end
   return outpath
 end
 


### PR DESCRIPTION
When running on other systems there won't be a /projects/pathogist directory, leave it up to end-user environment to find `kmc` and `kmc_tools`

Exit if either tool isn't available.
