### PR TITLE
Merge master into mentalist_v0.2 (#26)

### DIFF
--- a/src/MentaLiST.jl
+++ b/src/MentaLiST.jl
@@ -230,6 +230,9 @@ function build_db(args)
   info("Combining results for each locus ...")
   kmer_classification = combine_loci_classification(k, results, loci)
 
+  for (index, fasta_file) in enumerate(args["fasta_files"])
+    args["fasta_files"][index] = pop!(split(dirname(fasta_file), "/")) * "/" * basename(fasta_file)
+  end
   info("Saving DB ...")
   save_db(k, kmer_classification, loci, db_file, profile, args)
   info("Done!")

--- a/src/calling_functions.jl
+++ b/src/calling_functions.jl
@@ -18,12 +18,10 @@ function run_calling_pipeline(args)
 
   # prepend base path of the kmer database on to the relative paths for allele fasta files stored in the db
   for (index, file) in enumerate(build_args["fasta_files"])
-    build_args["fasta_files"][index] = dirname(args["db"]) * "/" * file
+    build_args["fasta_files"][index] = joinpath(dirname(args["db"]), file)
   end
   # check if scheme fasta files exist
-  for fasta_file in build_args["fasta_files"]
-    check_files(fasta_file)
-  end
+  check_files(build_args["fasta_files"])
   # process each sample:
   for (sample, fq_files) in sample_files
     info("Sample: $sample. Opening fastq file(s) and counting kmers ... ")


### PR DESCRIPTION
* new script to filter Mentalist flag symbols from the calls

* Add .travis.yml file (#18)

* Added travis.yml file

* Added 'Build Status' badge

* Update .travis.yml

* Update requirements for TravisCI testing

* kmer_class_for_locus function no longer exists

* Don't test on OS X

* Added coverage badge.

* Updated macOS install instructions

* Updated macOS install instructions

* Update README.md

* Update runtests.jl

* TravisCI testing on v0.5 is broken.

* Added <edam_operation> tag to 'mentalist call' galaxy tool (#21)

* fixed a bug in the cgmlst download, fasta file decompression could be incorrect in some cases

* adding import JSON; was not needed before because some other library was probably loading it, but for the tests we need this explicitly

* new messages while loading a kmer db, better idea of how much each large step takes

* lots of new unit tests and a new fastq testing file. Coverage should be much higher now.

* Change version info for galaxy tools in master branch to 'master'

* support for analysing multiple samples

* reorganizing the argparse code and a bit of refactoring

* adding all multi-sample functionality; better output for novel alleles; parallel downloading for enterobase

* small adjustment on a test

* Fix c_jejuni_fastq_file filename in test

* Adjusted kmer & vote numbers to match smaller test file.

* Update conda recipe

* Don't convert fasta_files paths to absolute paths (#23)

* Don't convert fasta_files paths to absolute paths

* Prepend database directory path on to relative paths for allele fasta files in db

* Don't create db_path variable, check for existence of fasta files

* Tidy up newlines

* Added test to check MLST calling after moving a database

* Relative paths in db (#25)

* Don't convert fasta_files paths to absolute paths

* Prepend database directory path on to relative paths for allele fasta files in db

* Don't create db_path variable, check for existence of fasta files

* Tidy up newlines

* Added test to check MLST calling after moving a database

* Fixed issue with scheme fasta loading during calling