### PR TITLE
Save MentaLiST version to kmer db

### DIFF
--- a/src/MentaLiST.jl
+++ b/src/MentaLiST.jl
@@ -217,7 +217,7 @@ function download_enterobase(args)
   build_db(args)
 end
 
-function build_db(args)
+function build_db(args, version=VERSION)
   # check if files exist:
   check_files(args["fasta_files"])
   # get arguments and call the kmer db builder for each locus:
@@ -234,7 +234,7 @@ function build_db(args)
     args["fasta_files"][index] = pop!(split(dirname(fasta_file), "/")) * "/" * basename(fasta_file)
   end
   info("Saving DB ...")
-  save_db(k, kmer_classification, loci, db_file, profile, args)
+  save_db(k, kmer_classification, loci, db_file, profile, args, version)
   info("Done!")
 end
 

--- a/src/build_db_functions.jl
+++ b/src/build_db_functions.jl
@@ -98,10 +98,11 @@ function kmer_class_for_each_locus(k::Int8, files::Vector{String})
   return results, loci
 end
 
-function save_db(k, kmer_db, loci, filename, profile, args)
+function save_db(k, kmer_db, loci, filename, profile, args, version)
 
   loci_list, weight_list, alleles_list, kmer_list, allele_ids_per_locus = kmer_db
   d = Dict(
+    "mentalist_version" => version,
     "loci_list"=> Blosc.compress(loci_list),
     "weight_list" => Blosc.compress(weight_list),
     "allele_ids_per_locus" => Blosc.compress(allele_ids_per_locus),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ include("../src/db_graph.jl")
 
 TEST_DIR = (dirname(@__FILE__))
 TMPDIR = mktempdir()
+VERSION = "testing"
 
 # encapsulate in a big test to get a summary of all in the end; if a testset fails, it will show the specific testset results,
 # otherwise will show just the total # of test passes.
@@ -60,7 +61,7 @@ TMPDIR = mktempdir()
 
     profile = nothing
     args = Dict("k" => K, "fasta_files" => l_pneumophila_cgmlst_loci_files)
-    save_db(K, kmer_classification, loci, l_pneumophila_cgmlst_db_file, profile, args)
+    save_db(K, kmer_classification, loci, l_pneumophila_cgmlst_db_file, profile, args, VERSION)
     @test isfile(l_pneumophila_cgmlst_db_file)
   end
 
@@ -83,7 +84,7 @@ TMPDIR = mktempdir()
 
     profile = nothing
     args = Dict("k" => K, "fasta_files" => c_jejuni_pubmlst_loci_files)
-    save_db(K, kmer_classification, loci, c_jejuni_pubmlst_db_file, profile, args)
+    save_db(K, kmer_classification, loci, c_jejuni_pubmlst_db_file, profile, args, VERSION)
     @test isfile(c_jejuni_pubmlst_db_file)
   end
 


### PR DESCRIPTION
(partially) addresses #37 .

Adds the following entry to the kmer database (text below produced with `h5dump`):

```
DATASET "mentalist_version" {
  DATATYPE  H5T_STRING {
    STRSIZE 5;
    STRPAD H5T_STR_NULLTERM;
    CSET H5T_CSET_UTF8;
    CTYPE H5T_C_S1;
  }
  DATASPACE  SCALAR
  DATA {
    (0): "0.2.2"
  }
}
```