### PR TITLE
Add subcommand db_info

### DIFF
--- a/src/MentaLiST.jl
+++ b/src/MentaLiST.jl
@@ -259,6 +259,12 @@ function db_info(args)
   loci = d["loci"]
   loci_list = Blosc.decompress(Int32, d["loci_list"])
   num_loci = length(loci_list)
+  mentalist_version = try
+    d["mentalist_version"]
+  catch
+    "unknown"
+  end
+  info("mentalist_version: $mentalist_version")
   info("k: $k")
   info("number of loci: $num_loci")
 end

--- a/src/MentaLiST.jl
+++ b/src/MentaLiST.jl
@@ -249,9 +249,18 @@ function build_db(args)
 end
 
 function db_info(args)
+  filename = args["db"]
   info("Opening kmer database ... ")
-  kmer_db, loci, loci2alleles, k, profile, build_args = open_db(args["db"])
+  # Compressed database, open and decompress/decode in memory:
+  d = JLD.load("$filename")
+  info("Finished the JLD load.")
+  build_args = JSON.parse(d["args"])
+  k = build_args["k"]
+  loci = d["loci"]
+  loci_list = Blosc.decompress(Int32, d["loci_list"])
+  num_loci = length(loci_list)
   info("k: $k")
+  info("number of loci: $num_loci")
 end
 
 ##### Main function: just calls the appropriate commands, with arguments:
@@ -268,7 +277,7 @@ elseif args["%COMMAND%"] == "build_db"
   build_db(args["build_db"])
 
 elseif args["%COMMAND%"] == "db_info"
-  include("calling_functions.jl")
+  import JLD: load
   db_info(args["db_info"])
 
 elseif args["%COMMAND%"] == "list_pubmlst"

--- a/src/MentaLiST.jl
+++ b/src/MentaLiST.jl
@@ -264,9 +264,9 @@ function db_info(args)
   catch
     "unknown"
   end
-  info("mentalist_version: $mentalist_version")
-  info("k: $k")
-  info("number of loci: $num_loci")
+  println("mentalist_version\t$mentalist_version")
+  println("k\t$k")
+  println("num_loci\t$num_loci")
 end
 
 ##### Main function: just calls the appropriate commands, with arguments:

--- a/src/MentaLiST.jl
+++ b/src/MentaLiST.jl
@@ -17,6 +17,9 @@ function parse_commandline()
       "build_db"
         help = "Build a MLST k-mer database, given a list of FASTA files."
         action = :command
+      "db_info"
+        help = "Extract information from an existing MentaLiST k-mer database"
+        action = :command
       "list_pubmlst"
         help = "List all available MLST schemes from www.pubmlst.org. "
         action = :command
@@ -110,6 +113,13 @@ function parse_commandline()
             help = "Profile file for known genotypes."
     end
 
+    @add_arg_table s["db_info"] begin
+      "--db"
+        help = "MentaLiST kmer database"
+        arg_type = String
+        required = true
+    end
+  
     # Listing functions, common options:
     s_list = ArgParseSettings()
     @add_arg_table s_list begin
@@ -238,6 +248,12 @@ function build_db(args)
   info("Done!")
 end
 
+function db_info(args)
+  info("Opening kmer database ... ")
+  kmer_db, loci, loci2alleles, k, profile, build_args = open_db(args["db"])
+  info("k: $k")
+end
+
 ##### Main function: just calls the appropriate commands, with arguments:
 
 args = parse_commandline()
@@ -245,10 +261,15 @@ args = parse_commandline()
 if args["%COMMAND%"] == "call"
   include("calling_functions.jl")
   call_mlst(args["call"])
+
 elseif args["%COMMAND%"] == "build_db"
   addprocs(args["build_db"]["threads"])
   include("build_db_functions.jl")
   build_db(args["build_db"])
+
+elseif args["%COMMAND%"] == "db_info"
+  include("calling_functions.jl")
+  db_info(args["db_info"])
 
 elseif args["%COMMAND%"] == "list_pubmlst"
   include("mlst_download_functions.jl")


### PR DESCRIPTION
Addresses #37. Adds new sub-command `db_info` that reads an existing MentaLiST database and reports relevant statistics.