### PR TITLE
Fixed filter to account for consecutive N's

### DIFF
--- a/scripts/filter_mlst_call_symbols.py
+++ b/scripts/filter_mlst_call_symbols.py
@@ -30,5 +30,6 @@ if __name__ == "__main__":
             genotype = f_in.readline().strip().split()
             genotype = "\t".join([genotype[0]] + [x.translate(all_chars, nodigs) for x in genotype[1:]])
             # genotype = "\t".join([genotype[0]] + [x for x in genotype[1:]])
-            genotype = re.sub(pattern='\t\t', repl='\t-1\t', string=genotype)
+            while re.search(pattern='\t\t', string = genotype):
+                genotype = re.sub(pattern='\t\t', repl='\t-1\t', string=genotype)
             f_out.write("%s\n" % genotype)


### PR DESCRIPTION
The previous script didn't work with consecutive N's, since re.sub cannot replace overlapping patterns.  I added a loop checking for the presence of remaining N's but the issue is that if there are lots of consecutive N's, this will increase the running time by a lot because of the linear search.

I'm not sure if there's a faster way of doing this but will update if I find one.