### PR TITLE
Remove references to Lumberjack library

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,19 @@
+name = "MentaLiST"
+uuid = "ae3b33b4-3937-11e9-0524-c13e9f2b4cb3"
+authors = ["Pedro Feijão <pedrofeijao1975@gmail.com>"]
+version = "1.0.0"
+
+[deps]
+ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
+BioSequences = "7e6ae17a-c86d-528c-b3b9-7f778a29fe59"
+Blosc = "a74b3585-a348-5f62-a45c-50e91977d574"
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+GZip = "92fee26a-97fe-5a0c-ad85-20a5f3185b63"
+Gurobi = "2e9cd046-0924-5485-92f1-d5272153d98b"
+JLD = "4138dd39-2aa7-5051-a626-17a0bb65d9c8"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+LightXML = "9c8b4983-aa76-5018-a973-4c85ecc9e179"
+TextWrap = "b718987f-49a8-5099-9789-dcd902bef87d"

--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ JLD = "4138dd39-2aa7-5051-a626-17a0bb65d9c8"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 LightXML = "9c8b4983-aa76-5018-a973-4c85ecc9e179"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 TextWrap = "b718987f-49a8-5099-9789-dcd902bef87d"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ JLD = "4138dd39-2aa7-5051-a626-17a0bb65d9c8"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 LightXML = "9c8b4983-aa76-5018-a973-4c85ecc9e179"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 TextWrap = "b718987f-49a8-5099-9789-dcd902bef87d"
 

--- a/Project.toml
+++ b/Project.toml
@@ -17,3 +17,9 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 LightXML = "9c8b4983-aa76-5018-a973-4c85ecc9e179"
 TextWrap = "b718987f-49a8-5099-9789-dcd902bef87d"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 1.1
+julia 1.0
 Distributed
 ArgParse
 BioSequences

--- a/src/mlst_download_functions.jl
+++ b/src/mlst_download_functions.jl
@@ -82,7 +82,7 @@ function download_pubmlst_scheme(target_species, output_dir, overwrite=false)
   @info("Searching for the scheme ... ")
   species = _find_publmst_species(xroot, target_species)
   if species == nothing
-    Lumberjack.warn("I did not find this scheme on pubmlst, please check the species spelling or the ID and try again.")
+    @warn("I did not find this scheme on pubmlst, please check the species spelling or the ID and try again.")
     exit(-1)
     return
   end
@@ -187,7 +187,7 @@ end
 function download_cgmlst_scheme(target_id, output_dir)
   id = _find_cgmlst_id(target_id)
   if id == nothing
-    Lumberjack.warn("Id/species ($target_id) not found!")
+    @warn("Id/species ($target_id) not found!")
     exit(-1)
   end
   @info("Downloading cgMLST scheme ...")


### PR DESCRIPTION
Fixes #85 

Remove references to Lumberjack logging library, use standard library Logging instead.