### PR TITLE
Fix issue with schemes with # in PubMLST

### DIFF
--- a/galaxy/data_managers/data_manager_mentalist_download_pubmlst/data_manager/mentalist_download_pubmlst.py
+++ b/galaxy/data_managers/data_manager_mentalist_download_pubmlst/data_manager/mentalist_download_pubmlst.py
@@ -17,6 +17,7 @@ DEFAULT_DATA_TABLE_NAMES = ["mentalist_databases"]
 
 
 def mentalist_download_pubmlst( data_manager_dict, kmer_size, scheme, params, target_directory, data_table_names=DEFAULT_DATA_TABLE_NAMES ):
+    scheme = scheme.replace('__pd__','#')
     translation_table = string.maketrans(string.punctuation, ("_" * 32))
     base_path = scheme.lower().replace(" ", "_").translate(translation_table) + "_pubmlst"
     today = datetime.date.today().isoformat()


### PR DESCRIPTION
I was trying to install the MLST scheme named **Escherichia coli#1** in the Galaxy tool (version `0.1.9`) and I noticed it was failing with:

```
Fatal error: Exit code 255 ()
WARNING: imported binding for VERSION overwritten in module Main
INFO: Searching for the scheme ... 
Error building database.
```

Looking a bit more closely, it looks like the command being run by Galaxy is:

```bash
mentalist_download_pubmlst.py 'dataset_xyz.dat' -k '31' --scheme 'Escherichia coli__pd__1'
```

That is, `#` gets swapped to `__pd__` in Galaxy (I believe Galaxy does this to strip out problematic characters in the command-line string).

I updated the `mentalist_download_pubmlst.py` to switch `__pd__` back to `#` and tested it out on our Galaxy server and it looks like it works.

I think this is safe to do (I don't think any PubMLST scheme contains `__pd__` in the name) so I am submitting as a pull request.

Please let me know if you have any comments about this fix. I also wasn't sure which branch I should be merging into so I just chose `master` for now.