### PR TITLE
Specify minimum Galaxy version of 18.09 for data managers

### DIFF
--- a/galaxy/data_managers/data_manager_mentalist_build_db/data_manager/mentalist_build_db.xml
+++ b/galaxy/data_managers/data_manager_mentalist_build_db/data_manager/mentalist_build_db.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="mentalist_build_db" name="MentaLiST Build DB" tool_type="manage_data" version="0.2.2">
+<tool id="mentalist_build_db" name="MentaLiST Build DB" tool_type="manage_data" version="0.2.2" profile="18.09">
   <requirements>
     <requirement type="package" version="0.2.2">mentalist</requirement>
   </requirements>

--- a/galaxy/data_managers/data_manager_mentalist_download_cgmlst/data_manager/mentalist_download_cgmlst.xml
+++ b/galaxy/data_managers/data_manager_mentalist_download_cgmlst/data_manager/mentalist_download_cgmlst.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="mentalist_download_cgmlst" name="MentaLiST Download from cgMLST" tool_type="manage_data" version="0.2.2">
+<tool id="mentalist_download_cgmlst" name="MentaLiST Download from cgMLST" tool_type="manage_data" version="0.2.2" profile="18.09">
   <requirements>
     <requirement type="package" version="0.2.2">mentalist</requirement>
   </requirements>

--- a/galaxy/data_managers/data_manager_mentalist_download_enterobase/data_manager/mentalist_download_enterobase.xml
+++ b/galaxy/data_managers/data_manager_mentalist_download_enterobase/data_manager/mentalist_download_enterobase.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="mentalist_download_enterobase" name="MentaLiST Download from Enterobase" tool_type="manage_data" version="0.2.2">
+<tool id="mentalist_download_enterobase" name="MentaLiST Download from Enterobase" tool_type="manage_data" version="0.2.2" profile="18.09">
   <requirements>
     <requirement type="package" version="0.2.2">mentalist</requirement>
   </requirements>

--- a/galaxy/data_managers/data_manager_mentalist_download_pubmlst/data_manager/mentalist_download_pubmlst.xml
+++ b/galaxy/data_managers/data_manager_mentalist_download_pubmlst/data_manager/mentalist_download_pubmlst.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="mentalist_download_pubmlst" name="MentaLiST Download from pubMLST" tool_type="manage_data" version="0.2.2">
+<tool id="mentalist_download_pubmlst" name="MentaLiST Download from pubMLST" tool_type="manage_data" version="0.2.2" profile="18.09">
   <requirements>
     <requirement type="package" version="0.2.2">mentalist</requirement>
   </requirements>


### PR DESCRIPTION
Tools of tool_type="manage_data" with a profile < 18.09 are loaded in legacy mode by Galaxy. Legacy mode preserves Galaxies python environment while activating the mentalist conda environment. This causes the tools to use the incorrect version of python.