### PR TITLE
Add docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM julia:0.6.3
+
+RUN apt-get update && apt-get install -y libhdf5-dev
+
+ADD https://github.com/WGS-TB/MentaLiST/archive/v0.2.4.tar.gz /tmp/mentalist.tar.gz
+
+RUN mkdir -p /opt/mentalist /tmp/mentalist &&\
+tar -xvf /tmp/mentalist.tar.gz --strip-components=1 -C /tmp/mentalist &&\
+mv /tmp/mentalist/src /opt/mentalist/ &&\
+#mv /tmp/mentalist/*.toml /opt/mentalist/ &&\
+mv /tmp/mentalist/scripts/* /opt/mentalist/ &&\
+rm -r /tmp/mentalist* &&\
+echo '#!/usr/bin/env bash \n\
+exec julia "/opt/mentalist/src/MentaLiST.jl" "$@" \n' > "/usr/bin/mentalist" &&\
+chmod +x "/usr/bin/mentalist"
+
+ENV JULIA_DEPOT_PATH="/usr/share/julia/site"
+
+RUN julia -e '\
+Pkg.update();\
+Pkg.add("Bio");\
+Pkg.add("OpenGene");\
+Pkg.add("Logging");\
+Pkg.add("ArgParse");\
+Pkg.add("Lumberjack");\
+Pkg.add("FastaIO");\
+Pkg.add("JLD");\
+Pkg.add("DataStructures");'


### PR DESCRIPTION
This is more of a bug report than a contribution.
I have been trying to get mentalist working but have been unsuccessful.

This PR includes a docker file that attempts to bundle a working version of mentalist.

Mentalist installs successfully, along with its dependencies, but fails to run.

<details><summary>Error log</summary>

```
/# mentalist download_cgmlst --db ./foo -k 31 -s 'Acinetobacter baumannii' -o /tmp
WARNING: imported binding for VERSION overwritten in module Main

WARNING: deprecated syntax "abstract FileFormat" at /root/.julia/v0.6/Bio/src/IO.jl:17.
Use "abstract type FileFormat end" instead.

WARNING: deprecated syntax "abstract AbstractFormattedIO" at /root/.julia/v0.6/Bio/src/IO.jl:22.
Use "abstract type AbstractFormattedIO end" instead.

WARNING: deprecated syntax "abstract AbstractReader<:AbstractFormattedIO" at /root/.julia/v0.6/Bio/src/IO.jl:54.
Use "abstract type AbstractReader<:AbstractFormattedIO end" instead.

WARNING: deprecated syntax "abstract AbstractWriter<:AbstractFormattedIO" at /root/.julia/v0.6/Bio/src/IO.jl:68.
Use "abstract type AbstractWriter<:AbstractFormattedIO end" instead.

WARNING: deprecated syntax "abstract Sequence" at /root/.julia/v0.6/Bio/src/seq/sequence.jl:20.
Use "abstract type Sequence end" instead.

WARNING: deprecated syntax "abstract Nucleotide" at /root/.julia/v0.6/Bio/src/seq/nucleotide.jl:27.
Use "abstract type Nucleotide end" instead.

WARNING: deprecated syntax "bitstype 8 DNANucleotide<:Nucleotide" at /root/.julia/v0.6/Bio/src/seq/nucleotide.jl:28.
Use "primitive type DNANucleotide<:Nucleotide 8 end" instead.

WARNING: deprecated syntax "bitstype 8 RNANucleotide<:Nucleotide" at /root/.julia/v0.6/Bio/src/seq/nucleotide.jl:29.
Use "primitive type RNANucleotide<:Nucleotide 8 end" instead.

WARNING: deprecated syntax "bitstype 8 AminoAcid" at /root/.julia/v0.6/Bio/src/seq/aminoacid.jl:11.
Use "primitive type AminoAcid 8 end" instead.

WARNING: deprecated syntax "abstract Alphabet" at /root/.julia/v0.6/Bio/src/seq/alphabet.jl:19.
Use "abstract type Alphabet end" instead.

WARNING: deprecated syntax "typealias NucleotideAlphabet Union{DNAAlphabet,RNAAlphabet}" at /root/.julia/v0.6/Bio/src/seq/alphabet.jl:46.
Use "const NucleotideAlphabet = Union{DNAAlphabet,RNAAlphabet}" instead.

WARNING: deprecated syntax "typealias DNASequence BioSequence{DNAAlphabet{4}}" at /root/.julia/v0.6/Bio/src/seq/bioseq.jl:56.
Use "const DNASequence = BioSequence{DNAAlphabet{4}}" instead.

WARNING: deprecated syntax "typealias RNASequence BioSequence{RNAAlphabet{4}}" at /root/.julia/v0.6/Bio/src/seq/bioseq.jl:57.
Use "const RNASequence = BioSequence{RNAAlphabet{4}}" instead.

WARNING: deprecated syntax "typealias AminoAcidSequence BioSequence{AminoAcidAlphabet}" at /root/.julia/v0.6/Bio/src/seq/bioseq.jl:58.
Use "const AminoAcidSequence = BioSequence{AminoAcidAlphabet}" instead.

WARNING: deprecated syntax "typealias CharSequence BioSequence{CharAlphabet}" at /root/.julia/v0.6/Bio/src/seq/bioseq.jl:59.
Use "const CharSequence = BioSequence{CharAlphabet}" instead.

WARNING: deprecated syntax "inner constructor BioSequence(...) around /root/.julia/v0.6/Bio/src/seq/bioseq.jl:51".
Use "BioSequence{A}(...) where A" instead.

WARNING: deprecated syntax "abstract SequenceGenerator{T}" at /root/.julia/v0.6/Bio/src/seq/randseq.jl:13.
Use "abstract type SequenceGenerator{T} end" instead.

WARNING: deprecated syntax "inner constructor StationaryGenerator(...) around /root/.julia/v0.6/Bio/src/seq/randseq.jl:20".
Use "StationaryGenerator{T}(...) where T" instead.

WARNING: deprecated syntax "bitstype 64 Kmer{T<:Nucleotide,K}<:Sequence" at /root/.julia/v0.6/Bio/src/seq/kmer.jl:33.
Use "primitive type Kmer{T<:Nucleotide,K}<:Sequence 64 end" instead.

WARNING: deprecated syntax "typealias DNAKmer{K} Kmer{DNANucleotide,K}" at /root/.julia/v0.6/Bio/src/seq/kmer.jl:35.
Use "DNAKmer{K} = Kmer{DNANucleotide,K}" instead.

WARNING: deprecated syntax "typealias RNAKmer{K} Kmer{RNANucleotide,K}" at /root/.julia/v0.6/Bio/src/seq/kmer.jl:36.
Use "RNAKmer{K} = Kmer{RNANucleotide,K}" instead.

WARNING: deprecated syntax "typealias DNACodon DNAKmer{3}" at /root/.julia/v0.6/Bio/src/seq/kmer.jl:37.
Use "const DNACodon = DNAKmer{3}" instead.

WARNING: deprecated syntax "typealias RNACodon RNAKmer{3}" at /root/.julia/v0.6/Bio/src/seq/kmer.jl:38.
Use "const RNACodon = RNAKmer{3}" instead.

WARNING: deprecated syntax "typealias FASTASeqRecord{S} SeqRecord{S,FASTAMetadata}" at /root/.julia/v0.6/Bio/src/seq/fasta/fasta.jl:32.
Use "FASTASeqRecord{S} = SeqRecord{S,FASTAMetadata}" instead.

WARNING: deprecated syntax "inner constructor FASTAReader(...) around /root/.julia/v0.6/Bio/src/seq/fasta/reader.jl:24".
Use "FASTAReader{S}(...) where S" instead.

WARNING: deprecated syntax "typealias FASTQSeqRecord{S} SeqRecord{S,FASTQMetadata}" at /root/.julia/v0.6/Bio/src/seq/fastq/fastq.jl:42.
Use "FASTQSeqRecord{S} = SeqRecord{S,FASTQMetadata}" instead.

WARNING: deprecated syntax "inner constructor FASTQReader(...) around /root/.julia/v0.6/Bio/src/seq/fastq/reader.jl:33".
Use "FASTQReader{S}(...) where S" instead.

WARNING: deprecated syntax "inner constructor ApproximateSearchQuery(...) around /root/.julia/v0.6/Bio/src/seq/search/approx.jl:19".
Use "ApproximateSearchQuery{S}(...) where S" instead.

WARNING: deprecated syntax "bitstype 32 Op" at /root/.julia/v0.6/Bio/src/seq/search/re.jl:443.
Use "primitive type Op 32 end" instead.

WARNING: deprecated syntax "inner constructor Regex(...) around /root/.julia/v0.6/Bio/src/seq/search/re.jl:574".
Use "Regex{T}(...) where T" instead.

WARNING: deprecated syntax "inner constructor RegexMatchIterator(...) around /root/.julia/v0.6/Bio/src/seq/search/re.jl:714".
Use "RegexMatchIterator{T,S}(...) where {T,S}" instead.

WARNING: deprecated syntax "inner constructor Stack(...) around /root/.julia/v0.6/Bio/src/seq/search/re.jl:793".
Use "Stack{T}(...) where T" instead.

WARNING: deprecated syntax "inner constructor SymbolRange(...) around /root/.julia/v0.6/Bio/src/seq/deprecated.jl:18".
Use "SymbolRange{T}(...) where T" instead.
WARNING: Implicit vectorized function is deprecated in favor of compact broadcast syntax.
Stacktrace:
 [1] depwarn(::String, ::Symbol) at ./deprecated.jl:70
 [2] @dep_vectorize_1arg(::ANY, ::ANY) at /root/.julia/v0.6/Compat/src/deprecated.jl:18
 [3] include_from_node1(::String) at ./loading.jl:576
 [4] include(::String) at ./sysimg.jl:14
 [5] include_from_node1(::String) at ./loading.jl:576
 [6] include(::String) at ./sysimg.jl:14
 [7] anonymous at ./<missing>:2
 [8] eval(::Module, ::Any) at ./boot.jl:235
 [9] process_options(::Base.JLOptions) at ./client.jl:286
 [10] _start() at ./client.jl:371
while loading /root/.julia/v0.6/Colors/src/algorithms.jl, in expression starting on line 152
WARNING: Implicit vectorized function is deprecated in favor of compact broadcast syntax.
Stacktrace:
 [1] depwarn(::String, ::Symbol) at ./deprecated.jl:70
 [2] @dep_vectorize_1arg(::ANY, ::ANY) at /root/.julia/v0.6/Compat/src/deprecated.jl:18
 [3] include_from_node1(::String) at ./loading.jl:576
 [4] include(::String) at ./sysimg.jl:14
 [5] include_from_node1(::String) at ./loading.jl:576
 [6] include(::String) at ./sysimg.jl:14
 [7] anonymous at ./<missing>:2
 [8] eval(::Module, ::Any) at ./boot.jl:235
 [9] process_options(::Base.JLOptions) at ./client.jl:286
 [10] _start() at ./client.jl:371
while loading /root/.julia/v0.6/Colors/src/algorithms.jl, in expression starting on line 153
WARNING: Implicit vectorized function is deprecated in favor of compact broadcast syntax.
Stacktrace:
 [1] depwarn(::String, ::Symbol) at ./deprecated.jl:70
 [2] @dep_vectorize_1arg(::ANY, ::ANY) at /root/.julia/v0.6/Compat/src/deprecated.jl:18
 [3] include_from_node1(::String) at ./loading.jl:576
 [4] include(::String) at ./sysimg.jl:14
 [5] include_from_node1(::String) at ./loading.jl:576
 [6] include(::String) at ./sysimg.jl:14
 [7] anonymous at ./<missing>:2
 [8] eval(::Module, ::Any) at ./boot.jl:235
 [9] process_options(::Base.JLOptions) at ./client.jl:286
 [10] _start() at ./client.jl:371
while loading /root/.julia/v0.6/Colors/src/algorithms.jl, in expression starting on line 154

WARNING: deprecated syntax "abstract AbstractInterval{T}" at /root/.julia/v0.6/IntervalTrees/src/IntervalTrees.jl:26.
Use "abstract type AbstractInterval{T} end" instead.

WARNING: deprecated syntax "abstract Node{K,V,B}" at /root/.julia/v0.6/IntervalTrees/src/IntervalTrees.jl:78.
Use "abstract type Node{K,V,B} end" instead.

WARNING: deprecated syntax "typealias IntervalTree{K,V} IntervalBTree{K,V,64}" at /root/.julia/v0.6/IntervalTrees/src/IntervalTrees.jl:240.
Use "IntervalTree{K,V} = IntervalBTree{K,V,64}" instead.

WARNING: deprecated syntax "inner constructor Slice(...) around /root/.julia/v0.6/IntervalTrees/src/slice.jl:11".
Use "Slice{T,N}(...) where {T,N}" instead.

WARNING: deprecated syntax "inner constructor InternalNode(...) around /root/.julia/v0.6/IntervalTrees/src/IntervalTrees.jl:100".
Use "InternalNode{K,V,B}(...) where {K,V,B}" instead.

WARNING: deprecated syntax "inner constructor LeafNode(...) around /root/.julia/v0.6/IntervalTrees/src/IntervalTrees.jl:127".
Use "LeafNode{K,V,B}(...) where {K,V,B}" instead.

WARNING: deprecated syntax "inner constructor IntervalBTree(...) around /root/.julia/v0.6/IntervalTrees/src/IntervalTrees.jl:148".
Use "IntervalBTree{K,V,B}(...) where {K,V,B}" instead.

WARNING: deprecated syntax "inner constructor IntervalBTree(...) around /root/.julia/v0.6/IntervalTrees/src/IntervalTrees.jl:160".
Use "IntervalBTree{K,V,B}(...) where {K,V,B}" instead.

WARNING: deprecated syntax "inner constructor Intersection(...) around /root/.julia/v0.6/IntervalTrees/src/IntervalTrees.jl:1022".
Use "Intersection{K,V,B}(...) where {K,V,B}" instead.

WARNING: deprecated syntax "inner constructor Intersection(...) around /root/.julia/v0.6/IntervalTrees/src/IntervalTrees.jl:1023".
Use "Intersection{K,V,B}(...) where {K,V,B}" instead.

WARNING: deprecated syntax "inner constructor IntervalIntersectionIterator(...) around /root/.julia/v0.6/IntervalTrees/src/IntervalTrees.jl:1158".
Use "IntervalIntersectionIterator{K,V,B}(...) where {K,V,B}" instead.

WARNING: deprecated syntax "inner constructor IntervalIntersectionIterator(...) around /root/.julia/v0.6/IntervalTrees/src/IntervalTrees.jl:1162".
Use "IntervalIntersectionIterator{K,V,B}(...) where {K,V,B}" instead.

WARNING: deprecated syntax "inner constructor IntersectionIterator(...) around /root/.julia/v0.6/IntervalTrees/src/IntervalTrees.jl:1229".
Use "IntersectionIterator{K,V1,B1,V2,B2}(...) where {K,V1,B1,V2,B2}" instead.

WARNING: deprecated syntax "typealias IntervalMap{K,V} IntervalTree{K,IntervalValue{K,V}}" at /root/.julia/v0.6/IntervalTrees/src/map.jl:4.
Use "IntervalMap{K,V} = IntervalTree{K,IntervalValue{K,V}}" instead.

WARNING: deprecated syntax "bitstype 8 Strand" at /root/.julia/v0.6/Bio/src/intervals/strand.jl:10.
Use "primitive type Strand 8 end" instead.

WARNING: deprecated syntax "abstract IntervalStream{T}" at /root/.julia/v0.6/Bio/src/intervals/interval.jl:210.
Use "abstract type IntervalStream{T} end" instead.

WARNING: deprecated syntax "typealias IntervalStreamOrArray{T} Union{Vector{Interval{T}},IntervalStream{T},Bio.IO.AbstractReader}" at /root/.julia/v0.6/Bio/src/intervals/interval.jl:212.
Use "IntervalStreamOrArray{T} = Union{Vector{Interval{T}},IntervalStream{T},Bio.IO.AbstractReader}" instead.

WARNING: deprecated syntax "inner constructor Interval(...) around /root/.julia/v0.6/Bio/src/intervals/interval.jl:19".
Use "Interval{T}(...) where T" instead.

WARNING: deprecated syntax "inner constructor Interval(...) around /root/.julia/v0.6/Bio/src/intervals/interval.jl:23".
Use "Interval{T}(...) where T" instead.

WARNING: deprecated syntax "inner constructor StreamBuffer(...) around /root/.julia/v0.6/Bio/src/intervals/stream_buffer.jl:22".
Use "StreamBuffer{T}(...) where T" instead.

WARNING: deprecated syntax "typealias IntervalCollectionTree{T} IntervalTree{Int64,Interval{T}}" at /root/.julia/v0.6/Bio/src/intervals/intervalcollection.jl:36.
Use "IntervalCollectionTree{T} = IntervalTree{Int64,Interval{T}}" instead.

WARNING: deprecated syntax "typealias IntervalCollectionTreeIteratorState{T} IntervalTrees.IntervalBTreeIteratorState{Int64,Interval{T},64}" at /root/.julia/v0.6/Bio/src/intervals/intervalcollection.jl:140.
Use "IntervalCollectionTreeIteratorState{T} = IntervalTrees.IntervalBTreeIteratorState{Int64,Interval{T},64}" instead.

WARNING: deprecated syntax "inner constructor IntervalCollection(...) around /root/.julia/v0.6/Bio/src/intervals/intervalcollection.jl:52".
Use "IntervalCollection{T}(...) where T" instead.

WARNING: deprecated syntax "inner constructor IntervalCollection(...) around /root/.julia/v0.6/Bio/src/intervals/intervalcollection.jl:58".
Use "IntervalCollection{T}(...) where T" instead.

WARNING: deprecated syntax "inner constructor IntervalCollectionIteratorState(...) around /root/.julia/v0.6/Bio/src/intervals/intervalcollection.jl:146".
Use "IntervalCollectionIteratorState{T}(...) where T" instead.

WARNING: deprecated syntax "inner constructor IntervalCollectionIteratorState(...) around /root/.julia/v0.6/Bio/src/intervals/intervalcollection.jl:150".
Use "IntervalCollectionIteratorState{T}(...) where T" instead.

WARNING: deprecated syntax "inner constructor IntersectIterator(...) around /root/.julia/v0.6/Bio/src/intervals/intervalcollection.jl:211".
Use "IntersectIterator{S,T}(...) where {S,T}" instead.

WARNING: deprecated syntax "inner constructor IntervalCollectionStreamIteratorState(...) around /root/.julia/v0.6/Bio/src/intervals/intervalcollection.jl:294".
Use "IntervalCollectionStreamIteratorState{S,TS,TV}(...) where {S,TS,TV}" instead.

WARNING: deprecated syntax "inner constructor IntervalCollectionStreamIteratorState(...) around /root/.julia/v0.6/Bio/src/intervals/intervalcollection.jl:298".
Use "IntervalCollectionStreamIteratorState{S,TS,TV}(...) where {S,TS,TV}" instead.

WARNING: deprecated syntax "inner constructor IntervalStreamIntersectIterator(...) around /root/.julia/v0.6/Bio/src/intervals/intervalstream.jl:20".
Use "IntervalStreamIntersectIterator{S,T,SS,TS}(...) where {S,T,SS,TS}" instead.

WARNING: deprecated syntax "typealias BinIndex Dict{UInt32,Vector{Chunk}}" at /root/.julia/v0.6/Bio/src/intervals/index/bgzfindex.jl:14.
Use "const BinIndex = Dict{UInt32,Vector{Chunk}}" instead.

WARNING: deprecated syntax "typealias LinearIndex Vector{VirtualOffset}" at /root/.julia/v0.6/Bio/src/intervals/index/bgzfindex.jl:17.
Use "const LinearIndex = Vector{VirtualOffset}" instead.

WARNING: deprecated syntax "typealias BEDInterval Interval{BEDMetadata}" at /root/.julia/v0.6/Bio/src/intervals/bed/bed.jl:73.
Use "const BEDInterval = Interval{BEDMetadata}" instead.

WARNING: deprecated syntax "bitstype 8 Operation" at /root/.julia/v0.6/Bio/src/align/operations.jl:11.
Use "primitive type Operation 8 end" instead.

WARNING: deprecated syntax "abstract AbstractAlignment" at /root/.julia/v0.6/Bio/src/align/types.jl:10.
Use "abstract type AbstractAlignment end" instead.

WARNING: deprecated syntax "abstract AbstractSubstitutionMatrix{S<:Real}" at /root/.julia/v0.6/Bio/src/align/submat.jl:17.
Use "abstract type AbstractSubstitutionMatrix{S<:Real} end" instead.

WARNING: deprecated syntax "inner constructor SubstitutionMatrix(...) around /root/.julia/v0.6/Bio/src/align/submat.jl:28".
Use "SubstitutionMatrix{T,S}(...) where {T,S}" instead.

WARNING: deprecated syntax "abstract AbstractScoreModel{T<:Real}" at /root/.julia/v0.6/Bio/src/align/models.jl:17.
Use "abstract type AbstractScoreModel{T<:Real} end" instead.

WARNING: deprecated syntax "abstract AbstractCostModel{T}" at /root/.julia/v0.6/Bio/src/align/models.jl:127.
Use "abstract type AbstractCostModel{T} end" instead.

WARNING: deprecated syntax "inner constructor AffineGapScoreModel(...) around /root/.julia/v0.6/Bio/src/align/models.jl:54".
Use "AffineGapScoreModel{T}(...) where T" instead.

WARNING: deprecated syntax "inner constructor CostModel(...) around /root/.julia/v0.6/Bio/src/align/models.jl:160".
Use "CostModel{T}(...) where T" instead.

WARNING: deprecated syntax "typealias Trace UInt8" at /root/.julia/v0.6/Bio/src/align/pairwise/algorithms/common.jl:20.
Use "const Trace = UInt8" instead.

WARNING: deprecated syntax "inner constructor NeedlemanWunsch(...) around /root/.julia/v0.6/Bio/src/align/pairwise/algorithms/needleman_wunsch.jl:15".
Use "NeedlemanWunsch{T}(...) where T" instead.

WARNING: deprecated syntax "inner constructor NeedlemanWunsch(...) around /root/.julia/v0.6/Bio/src/align/pairwise/algorithms/needleman_wunsch.jl:23".
Use "NeedlemanWunsch{T}(...) where T" instead.

WARNING: deprecated syntax "inner constructor BandedNeedlemanWunsch(...) around /root/.julia/v0.6/Bio/src/align/pairwise/algorithms/banded_needleman_wunsch.jl:23".
Use "BandedNeedlemanWunsch{T}(...) where T" instead.

WARNING: deprecated syntax "inner constructor BandedNeedlemanWunsch(...) around /root/.julia/v0.6/Bio/src/align/pairwise/algorithms/banded_needleman_wunsch.jl:33".
Use "BandedNeedlemanWunsch{T}(...) where T" instead.

WARNING: deprecated syntax "inner constructor SmithWaterman(...) around /root/.julia/v0.6/Bio/src/align/pairwise/algorithms/smith_waterman.jl:15".
Use "SmithWaterman{T}(...) where T" instead.

WARNING: deprecated syntax "inner constructor SmithWaterman(...) around /root/.julia/v0.6/Bio/src/align/pairwise/algorithms/smith_waterman.jl:23".
Use "SmithWaterman{T}(...) where T" instead.
WARNING: Method definition (::Type{Bio.Align.SAMWriter{T} where T<:IO})(IO) in module Align at /root/.julia/v0.6/Bio/src/align/hts/sam/writer.jl:14 overwritten at /root/.julia/v0.6/Bio/src/align/hts/sam/writer.jl:22.

WARNING: deprecated syntax "abstract MutationType" at /root/.julia/v0.6/Bio/src/var/mutation_counting.jl:18.
Use "abstract type MutationType end" instead.

WARNING: deprecated syntax "abstract EvolutionaryDistance" at /root/.julia/v0.6/Bio/src/var/distances.jl:14.
Use "abstract type EvolutionaryDistance end" instead.

WARNING: deprecated syntax "abstract UncorrectedDistance<:EvolutionaryDistance" at /root/.julia/v0.6/Bio/src/var/distances.jl:15.
Use "abstract type UncorrectedDistance<:EvolutionaryDistance end" instead.

WARNING: deprecated syntax "abstract CorrectedDistance<:EvolutionaryDistance" at /root/.julia/v0.6/Bio/src/var/distances.jl:16.
Use "abstract type CorrectedDistance<:EvolutionaryDistance end" instead.

WARNING: deprecated syntax "abstract TsTv<:CorrectedDistance" at /root/.julia/v0.6/Bio/src/var/distances.jl:17.
Use "abstract type TsTv<:CorrectedDistance end" instead.

WARNING: deprecated syntax "typealias SymString Union{Symbol,AbstractString}" at /root/.julia/v0.6/Bio/src/phylo/phylogeny.jl:158.
Use "const SymString = Union{Symbol,AbstractString}" instead.

WARNING: deprecated syntax "abstract DatingEstimate" at /root/.julia/v0.6/Bio/src/phylo/dating.jl:28.
Use "abstract type DatingEstimate end" instead.

WARNING: deprecated syntax "abstract DatingMethod" at /root/.julia/v0.6/Bio/src/phylo/dating.jl:29.
Use "abstract type DatingMethod end" instead.

WARNING: deprecated syntax "abstract StructuralElement" at /root/.julia/v0.6/Bio/src/structure/model.jl:89.
Use "abstract type StructuralElement end" instead.

WARNING: deprecated syntax "abstract AbstractAtom<:StructuralElement" at /root/.julia/v0.6/Bio/src/structure/model.jl:93.
Use "abstract type AbstractAtom<:StructuralElement end" instead.

WARNING: deprecated syntax "abstract AbstractResidue<:StructuralElement" at /root/.julia/v0.6/Bio/src/structure/model.jl:123.
Use "abstract type AbstractResidue<:StructuralElement end" instead.

WARNING: deprecated syntax "typealias StructuralElementOrList Union{StructuralElement,Vector{AbstractAtom},Vector{Atom},Vector{DisorderedAtom},Vector{AbstractResidue},Vector{Residue},Vector{DisorderedResidue},Vector{Chain},Vector{Model}}" at /root/.julia/v0.6/Bio/src/structure/model.jl:197.
Use "const StructuralElementOrList = Union{StructuralElement,Vector{AbstractAtom},Vector{Atom},Vector{DisorderedAtom},Vector{AbstractResidue},Vector{Residue},Vector{DisorderedResidue},Vector{Chain},Vector{Model}}" instead.

WARNING: deprecated syntax "typealias ArrayOrStringOrSeq Union{AbstractArray,AbstractString,BioSequence}" at /root/.julia/v0.6/Bio/src/util/windows.jl:20.
Use "const ArrayOrStringOrSeq = Union{AbstractArray,AbstractString,BioSequence}" instead.

WARNING: deprecated syntax "inner constructor EachWindowIterator(...) around /root/.julia/v0.6/Bio/src/util/windows.jl:35".
Use "EachWindowIterator{#s1140}(...) where #s1140" instead.
WARNING: Method definition (::Type{Bio.Align.SAMWriter{T} where T<:IO})(IO) in module Align at /root/.julia/v0.6/Bio/src/align/hts/sam/writer.jl:14 overwritten at /root/.julia/v0.6/Bio/src/align/hts/sam/writer.jl:22.
ERROR: LoadError: LoadError: LoadError: MethodError: no method matching convert(::Type{AssertionError}, ::String)
Closest candidates are:
  convert(!Matched::Type{Any}, ::ANY) at essentials.jl:28
  convert(::Type{T}, !Matched::T) where T at essentials.jl:29
AssertionError(::String) at ./coreimg.jl:14
update_valid_age!(::UInt64, ::UInt64, ::Core.Inference.InferenceState) at ./inference.jl:2353
add_backedge!(::Core.MethodInstance, ::Core.Inference.InferenceState) at ./inference.jl:2366
abstract_call_gf_by_type(::Any, ::Any, ::Core.Inference.InferenceState) at ./inference.jl:1421
abstract_call(::Any, ::Array{Any,1}, ::Array{Any,1}, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1897
abstract_eval_call(::Expr, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1927
abstract_eval(::Any, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1950
abstract_interpret(::Any, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:2084
typeinf_work(::Core.Inference.InferenceState) at ./inference.jl:2669
typeinf(::Core.Inference.InferenceState) at ./inference.jl:2787
typeinf_edge(::Method, ::Any, ::SimpleVector, ::Core.Inference.InferenceState) at ./inference.jl:2535
abstract_call_gf_by_type(::Any, ::Any, ::Core.Inference.InferenceState) at ./inference.jl:1420
abstract_call(::Any, ::Array{Any,1}, ::Array{Any,1}, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1897
abstract_eval_call(::Expr, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1927
abstract_eval(::Any, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1950
abstract_interpret(::Any, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:2084
typeinf_work(::Core.Inference.InferenceState) at ./inference.jl:2669
typeinf(::Core.Inference.InferenceState) at ./inference.jl:2787
typeinf_edge(::Method, ::Any, ::SimpleVector, ::Core.Inference.InferenceState) at ./inference.jl:2535
abstract_call_gf_by_type(::Any, ::Any, ::Core.Inference.InferenceState) at ./inference.jl:1420
abstract_call(::Any, ::Array{Any,1}, ::Array{Any,1}, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1897
abstract_eval_call(::Expr, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1927
abstract_eval(::Any, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1950
typeinf_work(::Core.Inference.InferenceState) at ./inference.jl:2722
typeinf(::Core.Inference.InferenceState) at ./inference.jl:2787
typeinf_edge(::Method, ::Any, ::SimpleVector, ::Core.Inference.InferenceState) at ./inference.jl:2535
abstract_call_gf_by_type(::Any, ::Any, ::Core.Inference.InferenceState) at ./inference.jl:1420
abstract_call(::Any, ::Array{Any,1}, ::Array{Any,1}, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1897
abstract_eval_call(::Expr, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1927
abstract_eval(::Any, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1950
abstract_interpret(::Any, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:2084
typeinf_work(::Core.Inference.InferenceState) at ./inference.jl:2669
typeinf(::Core.Inference.InferenceState) at ./inference.jl:2787
typeinf_edge(::Method, ::Any, ::SimpleVector, ::Core.Inference.InferenceState) at ./inference.jl:2535
abstract_call_gf_by_type(::Any, ::Any, ::Core.Inference.InferenceState) at ./inference.jl:1420
abstract_call(::Any, ::Tuple{}, ::Array{Any,1}, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1897
abstract_apply(::Any, ::Array{Any,1}, ::Array{Any,1}, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1561
abstract_call(::Any, ::Array{Any,1}, ::Array{Any,1}, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1689
abstract_eval_call(::Expr, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1927
abstract_eval(::Any, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1950
typeinf_work(::Core.Inference.InferenceState) at ./inference.jl:2722
typeinf(::Core.Inference.InferenceState) at ./inference.jl:2787
typeinf_edge(::Method, ::Any, ::SimpleVector, ::Core.Inference.InferenceState) at ./inference.jl:2535
abstract_call_gf_by_type(::Any, ::Any, ::Core.Inference.InferenceState) at ./inference.jl:1420
abstract_call(::Any, ::Tuple{}, ::Array{Any,1}, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1897
abstract_apply(::Any, ::Array{Any,1}, ::Array{Any,1}, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1561
abstract_call(::Any, ::Array{Any,1}, ::Array{Any,1}, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1689
abstract_eval_call(::Expr, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1927
abstract_eval(::Any, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1950
typeinf_work(::Core.Inference.InferenceState) at ./inference.jl:2722
typeinf(::Core.Inference.InferenceState) at ./inference.jl:2787
typeinf_edge(::Method, ::Any, ::SimpleVector, ::Core.Inference.InferenceState) at ./inference.jl:2535
abstract_call_gf_by_type(::Any, ::Any, ::Core.Inference.InferenceState) at ./inference.jl:1420
abstract_call(::Any, ::Tuple{}, ::Array{Any,1}, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1897
abstract_apply(::Any, ::Array{Any,1}, ::Array{Any,1}, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1561
abstract_call(::Any, ::Array{Any,1}, ::Array{Any,1}, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1689
abstract_eval_call(::Expr, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1927
abstract_eval(::Any, ::Array{Any,1}, ::Core.Inference.InferenceState) at ./inference.jl:1950
typeinf_work(::Core.Inference.InferenceState) at ./inference.jl:2722
typeinf(::Core.Inference.InferenceState) at ./inference.jl:2787
typeinf_frame(::Core.MethodInstance, ::Bool, ::Bool, ::Core.Inference.InferenceParams) at ./inference.jl:2504
typeinf_code(::Core.MethodInstance, ::Bool, ::Bool, ::Core.Inference.InferenceParams) at ./inference.jl:2583
typeinf_ext(::Core.MethodInstance, ::UInt64) at ./inference.jl:2622
macro expansion at ./loading.jl:180 [inlined]
(::Base.##693#695)() at ./task.jl:335

...and 1 more exception(s).

Stacktrace:
 [1] sync_end() at ./task.jl:287
 [2] macro expansion at ./task.jl:303 [inlined]
 [3] _require_from_serialized(::Int64, ::Symbol, ::String, ::Bool) at ./loading.jl:177
 [4] _require(::Symbol) at ./loading.jl:498
 [5] require(::Symbol) at ./loading.jl:405
 [6] include_from_node1(::String) at ./loading.jl:576
 [7] include(::String) at ./sysimg.jl:14
 [8] include_from_node1(::String) at ./loading.jl:576
 [9] include(::String) at ./sysimg.jl:14
 [10] include_from_node1(::String) at ./loading.jl:576
 [11] include(::String) at ./sysimg.jl:14
 [12] process_options(::Base.JLOptions) at ./client.jl:305
 [13] _start() at ./client.jl:371
while loading /opt/mentalist/src/db_graph.jl, in expression starting on line 2
while loading /opt/mentalist/src/build_db_functions.jl, in expression starting on line 6
while loading /opt/mentalist/src/MentaLiST.jl, in expression starting on line 314
MethodError(Core.Inference.convert, (AssertionError, "invalid age range update"), 0x0000000000000ac5)
```

</details>