### PR TITLE
Two small fixes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN julia -e 'using Pkg; Pkg.add([ "Distributed", "ArgParse", "JSON", "DataStruc
 
 RUN git clone https://github.com/WGS-TB/MentaLiST.git && \
     cd /MentaLiST && \
-    git checkout docker && \
+    git checkout docker -- && \
     chmod +x /MentaLiST/src/mentalist 
 
 WORKDIR /data

--- a/src/mlst_download_functions.jl
+++ b/src/mlst_download_functions.jl
@@ -95,7 +95,7 @@ function download_pubmlst_scheme(target_species, output_dir, overwrite=false)
     locus_name = _get_first_line(locus)
     @info("Downloading locus $locus_name ...")
     locus_url = content(locus["url"][1])
-    filepath = _download_to_folder(locus_url, output_dir)
+    filepath = _download_to_folder(locus_url, output_dir, overwrite, locus_name * ".fasta")
     push!(loci_files, filepath)
   end
   @info("Finished downloading.")


### PR DESCRIPTION
The first one is for a bug that has been annoying me for a while. Instead of downloading the whole schema `download_pubmlst` only downloads the fasta data for one locus because the names for all loci is `alleles_fasta`

The second one is for the Dockerfile, git gets confused when you checkout something that could be either a path or a branch name.

Best regards
Torsten